### PR TITLE
Updated composer to use official TCPDF repository

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('file')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/tcpdf.php')->end()
+                ->scalarNode('file')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/tcpdf.php')->end()
                 ->scalarNode('class')->defaultValue('TCPDF')->end()
             ->end()
         ;
@@ -45,13 +45,13 @@ class Configuration implements ConfigurationInterface
 
                         // Core configuration values
                         // These get defined when the TCPDF bundle is booted
-                        ->scalarNode('k_path_url')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/')->end()
-                        ->scalarNode('k_path_main')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/')->end()
-                        ->scalarNode('k_path_fonts')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/fonts/')->end()
+                        ->scalarNode('k_path_url')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/')->end()
+                        ->scalarNode('k_path_main')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/')->end()
+                        ->scalarNode('k_path_fonts')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/fonts/')->end()
                         ->scalarNode('k_path_cache')->defaultValue('%kernel.cache_dir%/tcpdf')->end()
                         ->scalarNode('k_path_url_cache')->defaultValue('%kernel.cache_dir%/tcpdf')->end()
-                        ->scalarNode('k_path_images')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/images/')->end()
-                        ->scalarNode('k_blank_image')->defaultValue('%kernel.root_dir%/../vendor/tcpdf/images/_blank.png')->end()
+                        ->scalarNode('k_path_images')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/images/')->end()
+                        ->scalarNode('k_blank_image')->defaultValue('%kernel.root_dir%/../vendor/tecnick.com/tcpdf/images/_blank.png')->end()
                         ->scalarNode('k_cell_height_ratio')->defaultValue(1.25)->end()
                         ->scalarNode('k_title_magnification')->defaultValue(1.3)->end()
                         ->scalarNode('k_small_ratio')->defaultValue(2/3)->end()

--- a/composer.json
+++ b/composer.json
@@ -10,28 +10,13 @@
             "email": "rich.sage@gmail.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "tcpdf",
-                "version": "dev-master",
-                "dist": {
-                    "url": "http://sourceforge.net/projects/tcpdf/files/latest/download?source=files",
-                    "type": "zip"
-                }
-
-            }
-        }
-    ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.0.*",
-        "tcpdf": "dev-master"
+        "symfony/framework-bundle": ">=2.0",
+        "tecnick.com/tcpdf": "*"
     },
     "autoload": {
-        "psr-0": { "WhiteOctober\\TCPDFBundle": "" },
-        "classmap": ["vendor/tcpdf"]
+        "psr-0": { "WhiteOctober\\TCPDFBundle": "" }
     },
     "target-dir": "WhiteOctober/TCPDFBundle"
 }


### PR DESCRIPTION
As TCPDF now has an official package on packagist, this should be used instead of the current repository definition, as this allows for proper versioning of the dependecies.
