### PR TITLE
Patch fix composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.0.*,2.1.*",
+        "symfony/framework-bundle": "2.0.*,2.1.*,2.2.*",
         "tcpdf": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Makes it allowed to work for symfony 2.1. and 2.2
