### PR TITLE
tcpdf requirement not working using composer to install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.0",
-        "tecnick.com/tcpdf": "*"
+        "tecnick.com/tcpdf": "dev-master"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\TCPDFBundle": "" }


### PR DESCRIPTION
When I try and install this bundle with composer I get the following error message:

```
whiteoctober/tcpdf-bundle dev-master requires tecnick.com/tcpdf * -> no matching package found.
```

changing "*" to "dev-master" allowed me to install tecnick.com/tcpdf
