### PR TITLE
#28 - Directory-Path without trailing slash

### DIFF
--- a/WhiteOctoberTCPDFBundle.php
+++ b/WhiteOctoberTCPDFBundle.php
@@ -41,6 +41,10 @@ class WhiteOctoberTCPDFBundle extends Bundle
                             $this->createDir($value);
                         }
 
+                        if(in_array($constKey, ['K_PATH_URL','K_PATH_MAIN','K_PATH_FONTS','K_PATH_CACHE','K_PATH_URL_CACHE','K_PATH_IMAGES'])) {
+                            $value .= (substr($value, -1) == '/' ? '' : '/');
+                        }
+
                         define($constKey, $value);
                     }
                 }


### PR DESCRIPTION
fix for Symfony version 2.4.5:
TCPDF ERROR: Could not include font definition file: helvetica
