### PR TITLE
Updated tcpdf package name to new vendor name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.0",
-        "tecnick.com/tcpdf": "*"
+        "tecnickcom/tcpdf": "*"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\TCPDFBundle": "" }


### PR DESCRIPTION
tecnick.com/tcpdf package is abandoned and no longer maintained. The author suggests using the tecnickcom/tcpdf package instead.