### PR TITLE
Remove erroneous trailing comma in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,5 @@
     },
     "autoload": {
         "psr-4": { "WhiteOctober\\TCPDFBundle\\": "" }
-    },
+    }
 }


### PR DESCRIPTION
The issue was introduced in https://github.com/whiteoctober/WhiteOctoberTCPDFBundle/pull/50; it meant that Packagist was failing to update.