### PR TITLE
Added setting constant for throwing exceptions (TCPDF) instead of a die 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('k_small_ratio')->defaultValue(2/3)->end()
                         ->scalarNode('k_thai_topchars')->defaultTrue()->end()
                         ->scalarNode('k_tcpdf_calls_in_html')->defaultFalse()->end()
+                        ->scalarNode('k_tcpdf_external_config')->defaultTrue()->end()
                         ->scalarNode('k_tcpdf_throw_exception_error')->defaultTrue()->end()
 
                         // Optional nice-to-have values

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,7 +57,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('k_small_ratio')->defaultValue(2/3)->end()
                         ->scalarNode('k_thai_topchars')->defaultTrue()->end()
                         ->scalarNode('k_tcpdf_calls_in_html')->defaultFalse()->end()
-                        ->scalarNode('k_tcpdf_external_config')->defaultTrue()->end()
+                        ->scalarNode('k_tcpdf_throw_exception_error')->defaultTrue()->end()
 
                         // Optional nice-to-have values
                         ->scalarNode('head_magnification')->defaultValue(1.1)->end()


### PR DESCRIPTION
We had a problem with the TCPDF.  A die was executed instead of an exception when an error occurred. TCPDF checks for K_TCPDF_THROW_EXCEPTION_ERROR constant when hitting an error. 

Setting `k_tcpdf_throw_exception_error: false` in `config.yml` can still execute a die() in TCPDF 